### PR TITLE
fix: robust PR detection in release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,15 +28,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          # Find associated PR
+          echo "Processing commit: $COMMIT_SHA"
+          
+          # Method 1: GitHub API Commits Pulls
           PR_DATA=$(gh api -X GET "repos/${{ github.repository }}/commits/$COMMIT_SHA/pulls" --jq '.[0]')
-          if [ -z "$PR_DATA" ] || [ "$PR_DATA" == "null" ]; then
+          
+          if [ -n "$PR_DATA" ] && [ "$PR_DATA" != "null" ]; then
+            PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+            echo "Found PR #$PR_NUMBER via API"
+          else
+            # Method 2: Parse from commit message (e.g., "Merge pull request #18 from...")
+            COMMIT_MSG=$(git log -1 --pretty=%B "$COMMIT_SHA")
+            PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '(?<=Merge pull request #)\d+' || echo "$COMMIT_MSG" | grep -oP '(?<=\(#)\d+(?=\)$)' || true)
+            
+            if [ -n "$PR_NUMBER" ]; then
+              echo "Found PR #$PR_NUMBER via commit message parsing"
+              PR_DATA=$(gh api -X GET "repos/${{ github.repository }}/pulls/$PR_NUMBER")
+            fi
+          fi
+
+          if [ -z "$PR_NUMBER" ] || [ -z "$PR_DATA" ] || [ "$PR_DATA" == "null" ]; then
             echo "No associated PR found for commit $COMMIT_SHA. Skipping automated release."
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
           BUMP_LABEL=$(echo "$PR_DATA" | jq -r '.labels[].name' | grep '^bump:' | head -n 1 || true)
 
           if [ -z "$BUMP_LABEL" ]; then


### PR DESCRIPTION
# Description

This PR makes the PR detection in the release workflow more robust. It adds a fallback to parse the PR number directly from the merge commit message (e.g., "Merge pull request #18...") if the GitHub API lookup (`commits/{sha}/pulls`) fails. This is necessary because the API can be slow to update right after a merge.

## 🔗 Related Issue

> Fixes #18

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

I verified the regex for PR number extraction and simulated the failure case locally. The workflow will now log which method it used to find the PR.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have updated 'action.yml' (if changing inputs/outputs)
- [x] I have verified the action runs successfully
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
